### PR TITLE
I/O Writing, plot parallellization, Count dropped frames

### DIFF
--- a/src/core/sensor_reconnection.py
+++ b/src/core/sensor_reconnection.py
@@ -19,24 +19,30 @@ class SensorsTask:
         
 
     async def run(self):
-        logger.error("!!!!!!!!!!!!!!!! - SensorsTask started.")
+        logger.info("SensorsTask started.")
         self._running = True
         while self._running:
             try:
                 data = await asyncio.wait_for(self.queue.get(), timeout=1.0)
-                # print(f"!!!! - Processing data: {data}")
                 if data is None:
                     continue
                 
-                data_time = data[2]
-                sensor_id = data[0]
-                value = data[1]
-                
-                if data is not None:
-                    for write in self.write_func:
-                        write(sensor_id, data_time, value)
+                # Dispatch synchronous callbacks in a thread executor
+                # to avoid blocking the asyncio event loop
+                await asyncio.to_thread(self._dispatch, data)
+            except asyncio.TimeoutError:
+                continue
             except Exception as e:
+                logger.error(f"SensorsTask error: {e}")
                 await asyncio.sleep(0.1)
+
+    def _dispatch(self, data: tuple) -> None:
+        """Process a single frame's callbacks (runs in thread executor)."""
+        sensor_id = data[0]
+        value = data[1]
+        data_time = data[2]
+        for write in self.write_func:
+            write(sensor_id, data_time, value)
 
     def start(self):
         print("Starting SensorsTask...")

--- a/src/core/sensor_reconnection.py
+++ b/src/core/sensor_reconnection.py
@@ -1,5 +1,6 @@
 import asyncio
 import logging
+import queue
 import time
 from typing import Callable, Optional
 from dataclasses import dataclass, field
@@ -11,9 +12,17 @@ from core.services.serial_handler import SerialHandler
 logger = logging.getLogger(__name__)
 
 class SensorsTask:
-    def __init__(self, queue: asyncio.Queue[tuple[SensorId, str, float]]):
-        self.queue = queue
-        self.write_func: list[Callable[[SensorId, float, str], None]] = []  # list of async functions to write sensor data
+    """
+    Consumer that drains the shared thread-safe queue.Queue and dispatches
+    data to registered callbacks.
+    
+    Bridges the threading world (serial readers) back to the asyncio world
+    (FastAPI) by using asyncio.to_thread for the blocking queue.get().
+    """
+
+    def __init__(self, data_queue: queue.Queue):
+        self.queue = data_queue
+        self.write_func: list[Callable[[SensorId, float, str], None]] = []
         self.serial_handlers: list[SerialHandler] = []
         self._running = False
         
@@ -23,18 +32,29 @@ class SensorsTask:
         self._running = True
         while self._running:
             try:
-                data = await asyncio.wait_for(self.queue.get(), timeout=1.0)
+                # Bridge: block in a thread executor waiting for data from
+                # the thread-safe queue, yielding the asyncio event loop
+                data = await asyncio.to_thread(self._blocking_get)
                 if data is None:
                     continue
                 
-                # Dispatch synchronous callbacks in a thread executor
-                # to avoid blocking the asyncio event loop
+                # Dispatch callbacks in a thread executor as well,
+                # keeping the event loop free
                 await asyncio.to_thread(self._dispatch, data)
-            except asyncio.TimeoutError:
-                continue
             except Exception as e:
                 logger.error(f"SensorsTask error: {e}")
                 await asyncio.sleep(0.1)
+
+    def _blocking_get(self):
+        """
+        Blocking get from queue.Queue with a 1-second timeout.
+        Returns None on timeout (allows checking self._running).
+        Runs in the asyncio thread executor.
+        """
+        try:
+            return self.queue.get(timeout=1.0)
+        except queue.Empty:
+            return None
 
     def _dispatch(self, data: tuple) -> None:
         """Process a single frame's callbacks (runs in thread executor)."""
@@ -47,7 +67,6 @@ class SensorsTask:
     def start(self):
         print("Starting SensorsTask...")
         asyncio.create_task(self.run())
-
 
     def stop(self):
         print("Stopping SensorsTask...")

--- a/src/core/services/file_writer.py
+++ b/src/core/services/file_writer.py
@@ -1,0 +1,268 @@
+"""
+file_writer.py — Background thread-based writer for CSV, raw log, and PIL graphique operations.
+
+Decouples all file I/O and PIL drawing from the asyncio event loop to eliminate
+jitter in the serial data pipeline.
+
+All heavy operations (disk writes, PIL draw.line) are processed sequentially
+in a single dedicated thread, ensuring:
+  1. No thread-safety issues with PIL Image objects
+  2. No event loop blocking from disk I/O
+  3. Batched writes for better throughput
+"""
+
+import csv
+import io
+import logging
+import os
+import queue
+import threading
+import time
+from dataclasses import dataclass
+from enum import Enum, auto
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+
+class _MsgType(Enum):
+    """Internal message types for the writer queue."""
+    RAW_LOG = auto()
+    CSV_ROW = auto()
+    PLOT = auto()
+    STOP = auto()
+
+
+@dataclass(slots=True)
+class _WriterMsg:
+    """Message sent to the writer thread."""
+    msg_type: _MsgType
+    payload: object = None
+
+
+class FileWriter:
+    """
+    Background thread that handles all file I/O and PIL drawing operations.
+
+    Usage:
+        writer = FileWriter()
+        writer.start(raw_path="/path/to/raw.log", csv_path="/path/to/raw_data.csv")
+        writer.log_raw("[1234.56] FORCE ASC2 ...")
+        writer.log_csv({"timestamp": "1234.560", "sensor_id": "FORCE", ...})
+        writer.enqueue_plot(graphique_obj, x_value, y_value)
+        writer.stop()  # Drains queue, closes files
+    """
+
+    # Maximum items to batch-dequeue per iteration for throughput
+    _BATCH_SIZE = 64
+
+    def __init__(self):
+        self._queue: queue.Queue[_WriterMsg] = queue.Queue(maxsize=8192)
+        self._thread: Optional[threading.Thread] = None
+
+        # File handles (owned exclusively by the writer thread)
+        self._raw_file = None
+        self._csv_file = None
+        self._csv_writer = None
+        self._csv_headers_written = False
+
+        # Stats
+        self._write_count = 0
+        self._drop_count = 0
+
+    @property
+    def is_running(self) -> bool:
+        return self._thread is not None and self._thread.is_alive()
+
+    def start(self, raw_path: str, csv_path: str) -> None:
+        """
+        Start the background writer thread and open output files.
+
+        Args:
+            raw_path: Path to the raw log file.
+            csv_path: Path to the CSV data file.
+        """
+        if self.is_running:
+            logger.warning("FileWriter already running, stopping first.")
+            self.stop()
+
+        # Reset state
+        self._write_count = 0
+        self._drop_count = 0
+        self._csv_headers_written = False
+
+        # Open files (on the calling thread — these are fast operations)
+        self._raw_file = open(raw_path, "w", buffering=8192)  # 8KB buffer
+        self._csv_file = open(csv_path, "w", newline="", buffering=8192)
+        self._csv_writer = None  # Initialized on first CSV row
+
+        # Clear any leftover messages
+        while not self._queue.empty():
+            try:
+                self._queue.get_nowait()
+            except queue.Empty:
+                break
+
+        self._thread = threading.Thread(
+            target=self._writer_loop,
+            daemon=True,
+            name="FileWriter",
+        )
+        self._thread.start()
+        logger.info("FileWriter started.")
+
+    def stop(self) -> None:
+        """
+        Signal the writer thread to stop, drain remaining messages, and close files.
+        Blocks until the thread has fully exited.
+        """
+        if not self.is_running:
+            return
+
+        # Send stop sentinel
+        try:
+            self._queue.put(_WriterMsg(_MsgType.STOP), timeout=5.0)
+        except queue.Full:
+            logger.error("FileWriter queue full, forcing stop.")
+
+        self._thread.join(timeout=10.0)
+        if self._thread.is_alive():
+            logger.error("FileWriter thread did not exit cleanly.")
+
+        self._thread = None
+        logger.info(
+            "FileWriter stopped. Wrote %d entries, dropped %d.",
+            self._write_count, self._drop_count,
+        )
+
+    def log_raw(self, line: str) -> None:
+        """
+        Enqueue a raw log line for writing. Non-blocking.
+
+        Args:
+            line: The raw log line (without trailing newline).
+        """
+        try:
+            self._queue.put_nowait(_WriterMsg(_MsgType.RAW_LOG, line))
+        except queue.Full:
+            self._drop_count += 1
+
+    def log_csv(self, row: dict) -> None:
+        """
+        Enqueue a CSV row dict for writing. Non-blocking.
+
+        Args:
+            row: Dict with column names matching the CSV headers.
+        """
+        try:
+            self._queue.put_nowait(_WriterMsg(_MsgType.CSV_ROW, row))
+        except queue.Full:
+            self._drop_count += 1
+
+    def enqueue_plot(self, graphique, x_value: float, y_value: float) -> None:
+        """
+        Enqueue a PIL draw.line operation. Non-blocking.
+
+        Args:
+            graphique: The Graphique object to plot on.
+            x_value: X coordinate (data space).
+            y_value: Y coordinate (data space).
+        """
+        try:
+            self._queue.put_nowait(
+                _WriterMsg(_MsgType.PLOT, (graphique, x_value, y_value))
+            )
+        except queue.Full:
+            self._drop_count += 1
+
+    # ---- Internal ----
+
+    def _writer_loop(self) -> None:
+        """Main writer loop: dequeues messages and processes them."""
+        try:
+            while True:
+                # Block on the first message
+                try:
+                    msg = self._queue.get(timeout=1.0)
+                except queue.Empty:
+                    continue
+
+                if msg.msg_type == _MsgType.STOP:
+                    # Drain remaining messages before exiting
+                    self._drain()
+                    break
+
+                self._process_msg(msg)
+
+                # Batch-process additional available messages for throughput
+                for _ in range(self._BATCH_SIZE - 1):
+                    try:
+                        msg = self._queue.get_nowait()
+                    except queue.Empty:
+                        break
+                    if msg.msg_type == _MsgType.STOP:
+                        self._drain()
+                        return
+                    self._process_msg(msg)
+
+        except Exception as e:
+            logger.error("FileWriter loop crashed: %s", e, exc_info=True)
+        finally:
+            self._close_files()
+
+    def _process_msg(self, msg: _WriterMsg) -> None:
+        """Process a single writer message."""
+        try:
+            if msg.msg_type == _MsgType.RAW_LOG:
+                if self._raw_file:
+                    self._raw_file.write(msg.payload + "\n")
+                    self._write_count += 1
+
+            elif msg.msg_type == _MsgType.CSV_ROW:
+                if self._csv_file and isinstance(msg.payload, dict):
+                    if self._csv_writer is None:
+                        headers = list(msg.payload.keys())
+                        self._csv_writer = csv.DictWriter(
+                            self._csv_file, fieldnames=headers
+                        )
+                        self._csv_writer.writeheader()
+                    self._csv_writer.writerow(msg.payload)
+                    self._write_count += 1
+
+            elif msg.msg_type == _MsgType.PLOT:
+                graphique, x_val, y_val = msg.payload
+                graphique.plot_point_on_graphique(x_val, y_val)
+                self._write_count += 1
+
+        except Exception as e:
+            logger.error("FileWriter error processing message: %s", e)
+
+    def _drain(self) -> None:
+        """Drain all remaining messages from the queue."""
+        while True:
+            try:
+                msg = self._queue.get_nowait()
+                if msg.msg_type != _MsgType.STOP:
+                    self._process_msg(msg)
+            except queue.Empty:
+                break
+
+    def _close_files(self) -> None:
+        """Flush and close all open file handles."""
+        if self._raw_file:
+            try:
+                self._raw_file.flush()
+                self._raw_file.close()
+            except Exception as e:
+                logger.error("Error closing raw file: %s", e)
+            self._raw_file = None
+
+        if self._csv_file:
+            try:
+                self._csv_file.flush()
+                self._csv_file.close()
+            except Exception as e:
+                logger.error("Error closing CSV file: %s", e)
+            self._csv_file = None
+
+        self._csv_writer = None

--- a/src/core/services/sensor_manager.py
+++ b/src/core/services/sensor_manager.py
@@ -1,5 +1,5 @@
 import os
-
+import queue
 import threading
 import time
 import logging
@@ -29,7 +29,7 @@ class SensorManager:
         self._emulation_task: Optional[asyncio.Task] = None
         self.offsets: list[float] = [0.0 for _ in SensorId]
         self._serial_handlers: list[SerialHandler] = []
-        self.queue: asyncio.Queue[tuple[SensorId, str, float]] = asyncio.Queue(maxsize=1024)
+        self.queue: queue.Queue[tuple[SensorId, str, float]] = queue.Queue(maxsize=1024)
         self._sensors_task: SensorsTask = SensorsTask(self.queue)
         self.notify_funcs: list[Callable[[SensorData], None]] = []
         self.zero_requests: dict[SensorId, int] = {}
@@ -243,7 +243,7 @@ class SensorManager:
             force_val = 500 + 500 * math.sin(elapsed) + random.uniform(-10, 10)
             line = f"ASC2 {int(elapsed * 1e6)} -39696 -3.577285e-02 {force_val:.6e} -0.000000e+00"
             if not self.queue.full():
-                await self.queue.put((SensorId.FORCE, line, time.time()))
+                self.queue.put_nowait((SensorId.FORCE, line, time.time()))
 
         # Emulate Displacement (Linear + Noise) with per-sensor phase offsets to avoid overlap
         phase_offsets = {
@@ -264,7 +264,7 @@ class SensorManager:
                 elapsed_us = int(elapsed * 1e6)
                 line = f"{elapsed_us} us SPC_VAL usSenderId=0x2E01 ulMicros={elapsed_us} Val={disp_val:.3f}"
                 if not self.queue.full():
-                    await self.queue.put((sensor_id, line, time.time()))
+                    self.queue.put_nowait((sensor_id, line, time.time()))
 
     def _notify(self, sensor_id: SensorId, time: float, value: float):
         if self.zero_requests.get(sensor_id, 0) > 0:

--- a/src/core/services/serial_handler.py
+++ b/src/core/services/serial_handler.py
@@ -89,6 +89,7 @@ class SerialHandler:
         self.sensor_id = sensor_id
         self.queue = queue
         self.running = False
+        self._drop_count = 0
         
     def start(self):
         self.running = True
@@ -98,6 +99,8 @@ class SerialHandler:
         self.running = False
         if self.serial and self.serial.is_open:
             self.serial.close()
+        if self._drop_count > 0:
+            logger.warning(f"SerialHandler {self.sensor_id.name}: total dropped frames = {self._drop_count}")
     
     async def read_serial(self):
         while self.running:
@@ -128,6 +131,11 @@ class SerialHandler:
                         if self.queue.full():
                             try:
                                 self.queue.get_nowait()
+                                self._drop_count += 1
+                                if self._drop_count % 100 == 1:
+                                    logger.warning(
+                                        f"{self.sensor_id.name}: dropped {self._drop_count} frames (queue full)"
+                                    )
                             except asyncio.QueueEmpty:
                                 pass
                         await self.queue.put((self.sensor_id, decoded_line, timestamp))

--- a/src/core/services/serial_handler.py
+++ b/src/core/services/serial_handler.py
@@ -1,7 +1,8 @@
-import asyncio
 import logging
+import queue
 import time
 import platform
+import threading
 import serial
 from core.models.sensor_enum import SensorId
 
@@ -74,14 +75,21 @@ def check_linux_serial_limits():
 
 
 class SerialHandler:
+    """
+    Dedicated blocking-thread serial reader.
+    
+    Each instance runs its own daemon thread that blocks on serial.readline().
+    Decoded lines are pushed into a thread-safe queue.Queue as
+    (SensorId, decoded_line, timestamp) tuples.
+    """
+
     def __init__(self, 
         sensor_id: SensorId,
         port: str,
-        queue: asyncio.Queue[tuple[SensorId, str, float]],
+        queue: queue.Queue,
         baudrate: int = 9600,
-        serial_timeout: float = 0.01,
+        serial_timeout: float = 0.5,
     ):
-        
         self.baudrate = baudrate
         self.port = port
         self.timeout = serial_timeout
@@ -90,62 +98,90 @@ class SerialHandler:
         self.queue = queue
         self.running = False
         self._drop_count = 0
+        self._thread: threading.Thread | None = None
         
     def start(self):
+        """Start the dedicated reader thread."""
         self.running = True
-        asyncio.create_task(self.read_serial())
+        self._thread = threading.Thread(
+            target=self._read_loop,
+            daemon=True,
+            name=f"SerialReader-{self.sensor_id.name}",
+        )
+        self._thread.start()
     
     def stop(self):
+        """Signal the thread to stop and wait for it to exit."""
         self.running = False
         if self.serial and self.serial.is_open:
             self.serial.close()
+        if self._thread and self._thread.is_alive():
+            self._thread.join(timeout=2.0)
         if self._drop_count > 0:
             logger.warning(f"SerialHandler {self.sensor_id.name}: total dropped frames = {self._drop_count}")
     
-    async def read_serial(self):
+    def _read_loop(self):
+        """
+        Blocking read loop (runs in its own thread).
+        
+        Connects to the serial port, reads lines, timestamps them,
+        and pushes them into the shared queue.
+        """
         while self.running:
             try:
+                # Connect / reconnect
                 if self.serial is None:
                     try:
-                        self.serial = await asyncio.to_thread(
-                            serial.Serial, port=self.port, baudrate=self.baudrate, timeout=self.timeout
+                        self.serial = serial.Serial(
+                            port=self.port,
+                            baudrate=self.baudrate,
+                            timeout=self.timeout,
                         )
-                        logger.info(f"SerialHandler for {self.sensor_id.name} reconnected to {self.port} at {self.baudrate} baud.")
+                        logger.info(
+                            f"SerialHandler for {self.sensor_id.name} connected "
+                            f"to {self.port} at {self.baudrate} baud."
+                        )
                         
-                        # Apply platform-specific optimizations
                         if platform.system() == "Linux":
                             optimize_linux_serial(self.serial)
                         
                     except Exception as e:
-                        logger.error(f"Failed to reconnect SerialHandler for {self.sensor_id.name} on {self.port}: {e}")
-                        await asyncio.sleep(0.5)
+                        logger.error(
+                            f"Failed to connect SerialHandler for "
+                            f"{self.sensor_id.name} on {self.port}: {e}"
+                        )
+                        time.sleep(0.5)
                         continue
                 
-                line = await asyncio.to_thread(self.serial.readline)
+                # Blocking read — waits up to self.timeout for a full line
+                line = self.serial.readline()
                 if line:
                     timestamp = time.time()
-                    
                     decoded_line = line.decode('utf-8', errors='ignore').strip()
                     
                     if decoded_line:
+                        # Drop oldest if queue is full
                         if self.queue.full():
                             try:
                                 self.queue.get_nowait()
                                 self._drop_count += 1
                                 if self._drop_count % 100 == 1:
                                     logger.warning(
-                                        f"{self.sensor_id.name}: dropped {self._drop_count} frames (queue full)"
+                                        f"{self.sensor_id.name}: dropped "
+                                        f"{self._drop_count} frames (queue full)"
                                     )
-                            except asyncio.QueueEmpty:
+                            except queue.Empty:
                                 pass
-                        await self.queue.put((self.sensor_id, decoded_line, timestamp))
+                        self.queue.put_nowait(
+                            (self.sensor_id, decoded_line, timestamp)
+                        )
                     
             except Exception as e:
-                logger.error(f"Error reading from serial port for {self.sensor_id}: {e}")
+                logger.error(f"Error reading serial port for {self.sensor_id.name}: {e}")
                 if self.serial:
                     try:
                         self.serial.close()
                     except Exception as close_error:
-                        logger.error(f"Error closing serial port for {self.sensor_id}: {close_error}")
+                        logger.error(f"Error closing serial port for {self.sensor_id.name}: {close_error}")
                     self.serial = None
-                await asyncio.sleep(1.0)
+                time.sleep(1.0)

--- a/src/core/services/test_manager.py
+++ b/src/core/services/test_manager.py
@@ -20,6 +20,7 @@ from core.models.circular_buffer import SensorDataStorage
 from core.config_loader import config_loader
 from core.processing.graphique import Graphique, GraphiqueConfig
 from core.services.sensor_manager import sensor_manager
+from core.services.file_writer import FileWriter
 
 logger = logging.getLogger(__name__)
 
@@ -52,10 +53,8 @@ class TestManager:
         
         self.start_time = 0.0
         
-        # File handles
-        self.raw_file = None           # raw.log - raw serial input
-        self.raw_csv_file = None       # raw_data.csv - uncalibrated sensor data
-        self.raw_csv_writer = None
+        # Background file writer (decouples I/O from event loop)
+        self.file_writer = FileWriter()
         self.current_test_dir = None
         
         self.max_interpolation_gap = 0.5 # seconds - max gap between points to allow interpolation, otherwise leave blank in CSV
@@ -192,12 +191,10 @@ class TestManager:
         metadata = self.current_test
         # Directory and metadata already created by prepare_test()
 
-        # Open raw file
-        self.raw_file = open(os.path.join(self.current_test_dir, "raw.log"), 'w', buffering=1) # Line buffered
-        
-        # Open CSV file for raw data
-        self.raw_csv_file = open(os.path.join(self.current_test_dir, "raw_data.csv"), 'w', newline='')
-        self.raw_csv_writer = None
+        # Start background file writer for raw log + CSV
+        raw_path = os.path.join(self.current_test_dir, "raw.log")
+        csv_path = os.path.join(self.current_test_dir, "raw_data.csv")
+        self.file_writer.start(raw_path, csv_path)
         
         # Initialize both graphiques (DISP_1 and ARC)
         self.graphique_disp1.reset()
@@ -222,13 +219,8 @@ class TestManager:
 
         logger.info(f"Test stopped (recording ended): {self.current_test.test_id}")
         
-        # Close files to stop recording
-        if self.raw_file:
-            self.raw_file.close()
-            self.raw_file = None
-        if self.raw_csv_file:
-            self.raw_csv_file.close()
-            self.raw_csv_file = None
+        # Stop the background file writer (drains queue and closes files)
+        self.file_writer.stop()
         
         # Save graphiques to test directory
         self.graphique_disp1.save_graphique(self.current_test_dir, "graphique_disp1.png")
@@ -359,12 +351,12 @@ class TestManager:
         return False
 
     def _on_serial_data(self, sensor_id: SensorId, time: float, line: str):
-        if self.is_running and self.raw_file:
-            self.raw_file.write(f"[{time}] {sensor_id.name} {line}\n")
+        if self.is_running and self.file_writer.is_running:
+            self.file_writer.log_raw(f"[{time}] {sensor_id.name} {line}")
 
     def _on_raw_sensor_data(self, sensor_data: SensorData):
         """Handle raw (uncalibrated) sensor data from SensorManager."""
-        if not self.is_running or not self.raw_csv_file:
+        if not self.is_running or not self.file_writer.is_running:
             return
         
         t = sensor_data.timestamp
@@ -373,34 +365,29 @@ class TestManager:
         value = sensor_data.value
         raw_value = sensor_data.raw_value
         
+        # Offload PIL graphique plotting to the FileWriter thread
         if sensor_id == SensorId.DISP_1:
             self.graphique_disp1_history = (sensor_data, self.graphique_disp1_history[1])
             
             if not math.isnan(self.graphique_disp1_history[0].value) and not math.isnan(self.graphique_disp1_history[1].value):
-                self.graphique_disp1.plot_point_on_graphique(self.graphique_disp1_history[0].value, self.graphique_disp1_history[1].value)
+                self.file_writer.enqueue_plot(self.graphique_disp1, self.graphique_disp1_history[0].value, self.graphique_disp1_history[1].value)
         
         elif sensor_id == SensorId.ARC:
             self.graphique_arc_history = (sensor_data, self.graphique_arc_history[1])
             
             if not math.isnan(self.graphique_arc_history[0].value) and not math.isnan(self.graphique_arc_history[1].value):
-                self.graphique_arc.plot_point_on_graphique(self.graphique_arc_history[0].value, self.graphique_arc_history[1].value)
+                self.file_writer.enqueue_plot(self.graphique_arc, self.graphique_arc_history[0].value, self.graphique_arc_history[1].value)
         
         elif sensor_id == SensorId.FORCE:
             self.graphique_disp1_history = (self.graphique_disp1_history[0], sensor_data)
             if not math.isnan(self.graphique_disp1_history[0].value) and not math.isnan(self.graphique_disp1_history[1].value):
-                self.graphique_disp1.plot_point_on_graphique(self.graphique_disp1_history[0].value, self.graphique_disp1_history[1].value)
+                self.file_writer.enqueue_plot(self.graphique_disp1, self.graphique_disp1_history[0].value, self.graphique_disp1_history[1].value)
                 
             self.graphique_arc_history = (self.graphique_arc_history[0], sensor_data)
             if not math.isnan(self.graphique_arc_history[0].value) and not math.isnan(self.graphique_arc_history[1].value):
-                self.graphique_arc.plot_point_on_graphique(self.graphique_arc_history[0].value, self.graphique_arc_history[1].value)
+                self.file_writer.enqueue_plot(self.graphique_arc, self.graphique_arc_history[0].value, self.graphique_arc_history[1].value)
         
         self._store_sensor_data(sensor_data)
-        
-        # Initialize CSV writer on first raw data
-        if self.raw_csv_writer is None:
-            headers = ["timestamp", "relative_time", "sensor_id", "raw_value", "offset"]
-            self.raw_csv_writer = csv.DictWriter(self.raw_csv_file, fieldnames=headers)
-            self.raw_csv_writer.writeheader()
         
         # Format numbers according to configured precision
         def _format_raw_value(sid_name: SensorId, val: float):
@@ -421,7 +408,7 @@ class TestManager:
             "raw_value": _format_raw_value(sensor_id, raw_value),
             "offset": _format_raw_value(sensor_id, sensor_data.offset)
         }
-        self.raw_csv_writer.writerow(row)
+        self.file_writer.log_csv(row)
 
     def _store_sensor_data(self, data: SensorData, epsilon: float = 1e-6):
         """Store data in circular buffers


### PR DESCRIPTION
**NE PAS MERGE SVP**

# Benchmark vs. ibef-src — Accuracy Analysis

## ibef-src Data Pipeline

```mermaid
graph LR
    S1[SerialHandler<br>sensor_0] -->|asyncio.to_thread<br>readline| Q[asyncio.Queue<br>maxsize=1024]
    S2[SerialHandler<br>sensor_1] --> Q
    S3[SerialHandler<br>...] --> Q
    S6[SerialHandler<br>sensor_5] --> Q
    Q --> ST[SensorsTask<br>consumer loop]
    ST -->|write_func| SM["SensorManager<br>_on_serial_data()"]
    SM -->|parse + _notify| TM["TestManager<br>file I/O, graphique,<br>circular buffer"]
```

## What the Benchmark Models Accurately

| Aspect | ibef-src Reality | Benchmark Model | Accuracy |
|---|---|---|---|
| **Concurrency model** | `asyncio` + `to_thread(readline)` | [AsyncScenario] does exactly this | ✅ **High** |
| **Shared queue** | Single `asyncio.Queue(1024)` for all 6 ports | Our async scenario uses a single `asyncio.Queue` | ✅ **High** |
| **Timestamp placement** | `time.time()` *after* [readline()] returns | Benchmark captures timestamp at same point | ✅ **High** |
| **Consumer processing delay** | `processing_time` param simulates load | Benchmark `--processing-time` flag | ✅ **High** |
| **Thread vs Process alternatives** | Not used in ibef-src, but benchmark tests them | Useful for "what-if" comparison | ✅ **Useful** |

## What the Benchmark Does NOT Model

### 1. Single Consumer Bottleneck (CRITICAL)

> [!CAUTION]
> ibef-src has a **single** [SensorsTask] draining the shared queue. It processes frames **sequentially** — one `await queue.get()` at a time, then calls **synchronous** [write_func] callbacks.

The benchmark consumer sleeps to simulate load, but the **real** consumer does:

```python
# SensorsTask.run() — sequential processing of ALL 6 sensors through 1 coroutine
data = await asyncio.wait_for(self.queue.get(), timeout=1.0)
for write in self.write_func:
    write(sensor_id, data_time, value)  # SYNCHRONOUS calls
```

Each [write_func] call triggers:
- [_on_serial_data()] → string parsing (`split()`, float conversion)
- [_on_raw_sensor_data()] → CSV row write (file I/O), PIL graphique plotting, circular buffer storage

**Impact:** If any single callback is slow (e.g., PIL plotting, CSV flush), it blocks the consumer from reading the next frame, causing queue backpressure.

**To model this accurately:** Set `--processing-time` to the measured time of your actual [_notify()] + [_on_raw_sensor_data()] chain (~1-5ms typically, but can spike with PIL operations).

### 2. Synchronous Callbacks on the Event Loop

> [!WARNING]
> [SensorsTask] calls [write_func] callbacks synchronously. Since `SensorsTask.run()` is a coroutine on the asyncio loop, these synchronous callbacks **block the event loop** during parsing + file I/O.

The benchmark's [async_consumer] uses `asyncio.sleep()` which **yields** to the loop. The real code does **not** yield — it blocks. This means the benchmark's async scenario will show **better** latency than reality.

### 3. Queue Overflow Policy

ibef-src's [SerialHandler] drops the **oldest** frame when the queue is full:
```python
if self.queue.full():
    self.queue.get_nowait()  # Drop oldest
await self.queue.put(...)
```

The benchmark queue has no size limit and never drops. Under heavy consumer load (`processing_time > 0`), the benchmark won't show frame drops that would happen in production.

### 4. Parsing Overhead

Real parsing ([_parse_force], [_parse_motion]) involves string splitting, float conversion, and conditional logic. The benchmark consumer does zero parsing. This adds ~0.1-1ms per frame that compounds across 6 sensors sharing one consumer.

### 5. File I/O Impact

`TestManager._on_raw_sensor_data()` writes CSV rows synchronously. Even with `buffering=1` (line-buffered), this can cause periodic latency spikes when the OS flushes buffers to disk.

## Verdict: What the Benchmark Reveals

| Bottleneck Type | Benchmark Detects It? | Notes |
|---|---|---|
| **Serial read latency** (OS/driver level) | ✅ Yes | Core purpose of the benchmark |
| **asyncio vs threading vs multiprocessing** | ✅ Yes | Direct comparison |
| **Blocking vs polling read strategy** | ✅ Yes | Direct comparison |
| **Consumer processing delay** | ⚠️ Partial | Use `--processing-time` to approximate |
| **Single-consumer queue bottleneck** | ⚠️ Partial | Visible when `processing_time` > frame interval |
| **Synchronous callbacks blocking event loop** | ❌ No | Benchmark uses `asyncio.sleep` (cooperative) |
| **Queue overflow / frame drops** | ❌ No | Benchmark has unbounded queue |
| **File I/O jitter** | ❌ No | No disk writes in benchmark consumer |
| **PIL graphique plotting latency** | ❌ No | Not modeled |

## Recommendations

1. **Run the benchmark with `processing_time = 0.005`** (~5ms) to approximate your real consumer overhead. This is the most impactful tuning.

2. **The async scenario is the most relevant** since ibef-src uses exactly this architecture. The threading/processing scenarios are useful as "what-if you switched?" comparisons.

3. **The biggest real bottleneck is likely the single-consumer design**, not the serial read strategy. To verify, instrument `SensorsTask.run()` with timing around each [write_func] call.

4. **Consider moving file I/O out of the hot path** — write CSV rows from a separate thread/task to decouple disk latency from the sensor read pipeline.